### PR TITLE
Add in missing line_numbers flag for code example

### DIFF
--- a/en/step_6.md
+++ b/en/step_6.md
@@ -53,6 +53,7 @@ The `bounce` animation runs with `ease` timing so the animation starts and ends 
 ---
 language: css
 filename: animation.css
+line_numbers: true
 line_number_start: 16
 line_highlights: 16-19
 ---


### PR DESCRIPTION
Fixes this problem where the line numbers are missing, but a random one appears:

<img width="622" alt="Screenshot 2022-12-07 at 10 48 41" src="https://user-images.githubusercontent.com/789846/206159562-d6781356-b7f7-48bc-b262-a17c6b0814ae.png">
